### PR TITLE
fix: fixed coin's value

### DIFF
--- a/reconhecimento_moedas/app/Appstreamlit.py
+++ b/reconhecimento_moedas/app/Appstreamlit.py
@@ -55,9 +55,13 @@ class CoinRecognition(VideoTransformerBase):
                 cv2.rectangle(img, (x, y), (x + w, y + h), (0, 255, 0), 2)
                 cv2.putText(img, coin_class, (x, y), cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 255, 255), 2)
 
-        # Exibir contagem de moedas
+        total_value = 0
+    
         for coin, count in coins_count.items():
-            st.write(f"{coin}: {count}")
+            total_value += count * coin_values[coin]
+        
+        # exibindo dinheiro total
+        cv2.putText(img, f"Total: R$ {total_value:.2f}", (10, 50), cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 255, 255), 2)
 
         return img
 


### PR DESCRIPTION
Foi ajustado o contador total dos valores das moedas.

##### como estava antes:

```python 

# Exibir contagem de moedas
for coin, count in coins_count.items():
    st.write(f"{coin}: {count}")

return img
```

##### após a mudança:

```python 
total_value = 0
    
for coin, count in coins_count.items():
    total_value += count * coin_values[coin]

# exibindo dinheiro total
cv2.putText(img, f"Total: R$ {total_value:.2f}", (10, 50), cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 255, 255), 2)
```

Com essa mudança, agora será exibido o valor total em reais das moedas que foram detectadas na imagem.
